### PR TITLE
Enable reverse dependency rebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
   prepare:
     name: Determine package to build
     runs-on: ubuntu-24.04
-    if: "!contains(github.event.head_commit.message, 'Deleting packages')"
     outputs:
       repo_url: ${{ steps.lookup.outputs.repo_url }}
       repo_name: ${{ steps.lookup.outputs.repo_name }}
@@ -438,6 +437,7 @@ jobs:
     if: ${{ always() && needs.source.outputs.package }}
     outputs:
       deployed_packages: ${{ steps.deployment.outputs.deployed_packages }}
+      version_bump: ${{ steps.deployment.outputs.version_bump }}
     steps:
       - id: download
         continue-on-error: true
@@ -490,3 +490,15 @@ jobs:
           package: ${{ needs.prepare.outputs.repo_name }}
           has_app: ${{ needs.prepare.outputs.universe_app }}
           is_rebuild: ${{ needs.prepare.outputs.is_rebuild }}
+
+  rechecks:
+    name: Trigger rebuilds for dependents
+    runs-on: ubuntu-24.04
+    needs: [source, deploy]
+    if: needs.deploy.outputs.version_change
+    steps:
+      - name: Trigger rebuilds
+        uses: r-universe-org/rebuilds@master
+        env:
+          GITHUB_PAT: ${{ secrets.BOT_TOKEN }}
+          TRIGGER_REVDEPS: ${{ needs.source.outputs.package }}

--- a/build.yml
+++ b/build.yml
@@ -15,8 +15,29 @@ name: Build package
 run-name: ${{ github.event.head_commit.message || format('{0} (rebuild)', inputs.package) }}
 
 jobs:
+  prepare:
+    if: "!contains(github.event.head_commit.message, 'Deleting packages')"
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      package: ${{ steps.lookup.outputs.package }}
+    steps:
+      - name: Determine package name
+        id: lookup
+        run: |
+          if [ "${{inputs.package}}" ]; then
+          package="${{inputs.package}}"
+          else
+          package=$(echo "${{github.event.head_commit.message}}" | cut -d " " -f1)
+          fi
+          echo "package=$package" >> $GITHUB_OUTPUT
+
   build:
+    needs: prepare
     name: Build and deploy
+    concurrency:
+      group: ${{ needs.prepare.outputs.package }}
+      cancel-in-progress: true
     uses: r-universe-org/workflows/.github/workflows/build.yml@v2
     with:
       package: ${{inputs.package}}


### PR DESCRIPTION
This is mostly for multiverse. 

When a package bumps the version number, we also trigger rebuilds of the reverse dependencies after the package has been deployed. This ensures the results are current.

This is experimental and we have to evaluate how expensive this is going to be and if it really effective in revealing problems that we do not already detect. Maybe it should be opt-in. 

Closes https://github.com/r-universe-org/help/issues/369
