### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,7 +385,7 @@ jobs:
       - name: Store ${{needs.source.outputs.package}}.BiocCheck
         id: artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bioc-checks
           path: ${{needs.source.outputs.package}}.BiocCheck

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,7 @@ jobs:
       version_change: ${{ steps.deployment.outputs.version_change }}
     steps:
       - name: Download package files
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
       - name: Upload site to rOpenSci docs server
         if: ${{ needs.build.result != 'cancelled' && needs.prepare.outputs.organization == 'ropensci' }}
         continue-on-error: true


### PR DESCRIPTION
## Summary
- Updates third-party GitHub Actions in `.github/workflows/` to their latest major versions.

| Action | Before | After |
| --- | --- | --- |
| actions/upload-artifact | v6 | v7 |
| actions/download-artifact | v7 | v8 |

## Test plan
- [ ] Trigger the affected workflow(s) and confirm they still run.